### PR TITLE
feat: mobile support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - Target: Obsidian Community Plugin (TypeScript → bundled JavaScript).
 - Entry point: `src/main.ts` compiled to `main.js` and loaded by Obsidian.
 - Required release artifacts: `main.js`, `manifest.json`, `styles.css`.
-- `isDesktopOnly: true` in `manifest.json` — desktop-only APIs are fine here, but note `manifest-beta.json` currently sets `isDesktopOnly: false`; keep these in sync when changing platform support.
+- `isDesktopOnly: false` in `manifest.json` (and `manifest-beta.json`) — the plugin runs on mobile. Do **not** introduce Node/Electron-only APIs; guard any desktop-only behavior behind `this.app.isMobile`. Keep the flag in sync across both manifests.
 
 ## Environment & tooling
 
@@ -126,7 +126,12 @@ Follow Obsidian's Developer Policies and Plugin Guidelines:
 
 ## Mobile
 
-- `isDesktopOnly: true` in `manifest.json` — this plugin is not expected to run on mobile. If that changes, audit for Node/Electron-only API usage first.
+- `isDesktopOnly: false` — the plugin is expected to run on mobile (phone and tablet).
+- No Node/Electron APIs anywhere in `src/` — keep it that way (`require`, `fs`, `path`, `os`, `child_process`, `electron`, `FileSystemAdapter`).
+- Guard desktop-only behavior behind `this.app.isMobile`. Known cases: the Live Preview reload path (`reloadIfNeeded`/`needsReload` in `main.ts`) and anything assuming a visible status bar — the status bar is hidden by default on mobile, so the ribbon button and command palette are the primary entry points there.
+- Per-platform active workspace is already tracked separately (`activeWorkspaceMobile` / `activeWorkspaceDesktop` in `settings.ts`, switched on `app.isMobile`).
+- Row action buttons in the switcher/mode modals are hover-revealed on desktop; on mobile (no hover) they render always-visible via the `.is-mobile` body class in `styles.css`.
+- Test with the desktop "Emulate mobile" developer toggle first, then on a real device via BRAT.
 
 ## Agent do/don't
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,8 +128,9 @@ Follow Obsidian's Developer Policies and Plugin Guidelines:
 
 - `isDesktopOnly: false` — the plugin is expected to run on mobile (phone and tablet).
 - No Node/Electron APIs anywhere in `src/` — keep it that way (`require`, `fs`, `path`, `os`, `child_process`, `electron`, `FileSystemAdapter`).
-- Guard desktop-only behavior behind `this.app.isMobile`. Known cases: the Live Preview reload path (`reloadIfNeeded`/`needsReload` in `main.ts`) and anything assuming a visible status bar — the status bar is hidden by default on mobile, so the ribbon button and command palette are the primary entry points there.
-- Per-platform active workspace is already tracked separately (`activeWorkspaceMobile` / `activeWorkspaceDesktop` in `settings.ts`, switched on `app.isMobile`).
+- Workspace Modes is desktop-only: it snapshots/restores Obsidian's core `app.json`, which is shared across platforms. Route every runtime Modes branch through the `modesEnabled` getter (`workspaceSettings && !app.isMobile`) rather than adding scattered `app.isMobile` checks — that includes the Live Preview reload path, which only runs inside a `modesEnabled` block.
+- The status bar is hidden by default on mobile. The **Open workspace switcher** command is the always-available entry point; the sidebar ribbon icon is off by default (same as desktop) and can be toggled on in settings.
+- Per-platform active workspace is tracked separately (`activeWorkspaceMobile` / `activeWorkspaceDesktop` in `settings.ts`, switched on `app.isMobile`).
 - Row action buttons in the switcher/mode modals are hover-revealed on desktop; on mobile (no hover) they render always-visible via the `.is-mobile` body class in `styles.css`.
 - Test with the desktop "Emulate mobile" developer toggle first, then on a real device via BRAT.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Workspaces can be deleted by either using the trach can icon next to the workspa
 
 Workspaces Plus runs on mobile (phone and tablet). A few differences from desktop:
 
-- Obsidian hides the status bar on mobile, so the workspace indicator lives elsewhere: the **sidebar ribbon icon** is enabled by default on mobile, and the **Open workspace switcher** command is always available. The ribbon toggle in settings still lets you turn the icon off.
+- Obsidian hides the status bar on mobile, so the status-bar workspace indicator isn't shown. Use the **Open workspace switcher** command (assign it to the mobile toolbar or a hotkey), or turn on **Show workspace sidebar ribbon icon** in settings — it's off by default, the same as on desktop.
 - The switcher and picker show their rename / delete / platform actions inline (no hover needed) with larger touch targets.
 - **Workspace Modes is desktop only.** Modes snapshot and restore Obsidian's core configuration, which is shared with mobile, so applying them on a phone or tablet would overwrite mobile-specific settings. Plain workspace switching, renaming, saving, overrides, and file tracking all work normally on mobile.
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ Workspaces can be deleted by either using the trach can icon next to the workspa
   - Example: 1 Journal/{{date:YYYY}}/{{date:YYYY-MM}}/{{date:YYYY-MM-DD}}.md
 - Switch to the workspace and the page will be loaded with the value from the override with the variables replaced.
 
+### Mobile
+
+Workspaces Plus runs on mobile (phone and tablet). A few differences from desktop:
+
+- Obsidian hides the status bar on mobile, so the workspace indicator lives elsewhere: the **sidebar ribbon icon** is enabled by default on mobile, and the **Open workspace switcher** command is always available. The ribbon toggle in settings still lets you turn the icon off.
+- The switcher and picker show their rename / delete / platform actions inline (no hover needed) with larger touch targets.
+- **Workspace Modes is desktop only.** Modes snapshot and restore Obsidian's core configuration, which is shared with mobile, so applying them on a phone or tablet would overwrite mobile-specific settings. Plain workspace switching, renaming, saving, overrides, and file tracking all work normally on mobile.
+
 ## Extra
 
 <details>

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "workspaces-plus",
   "name": "Workspaces Plus",
-  "version": "0.4.18",
+  "version": "0.4.20",
   "minAppVersion": "1.8.7",
   "description": "Quickly switch and manage workspaces",
   "author": "NothingIsLost",

--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,5 @@
   "description": "Quickly switch and manage workspaces",
   "author": "NothingIsLost and Johnny ✨",
   "authorUrl": "https://github.com/nothingislost",
-  "isDesktopOnly": true
+  "isDesktopOnly": false
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "rollup --config rollup.config.js -w",
     "build": "rollup --config rollup.config.js --environment BUILD:production",
-    "test": "node tests/workspaceCycle.test.js",
+    "test": "node tests/workspaceCycle.test.js && node tests/mobileGating.test.js",
     "lint": "eslint .",
     "release": "auto shipit"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,7 +124,14 @@ export default class WorkspacesPlus extends Plugin {
   }
 
   async loadSettings() {
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, (await this.loadData()) as Partial<WorkspacesPlusSettings>);
+    const data = (await this.loadData()) as Partial<WorkspacesPlusSettings> | null;
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, data);
+    // Mobile hides the status bar by default, so the sidebar ribbon icon is the primary
+    // visible entry point there. Default it on when the user hasn't made an explicit choice;
+    // an existing config that set it to false is left untouched.
+    if (this.app.isMobile && (data == null || data.workspaceSwitcherRibbon === undefined)) {
+      this.settings.workspaceSwitcherRibbon = true;
+    }
   }
 
   async saveSettings() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,14 +124,7 @@ export default class WorkspacesPlus extends Plugin {
   }
 
   async loadSettings() {
-    const data = (await this.loadData()) as Partial<WorkspacesPlusSettings> | null;
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, data);
-    // Mobile hides the status bar by default, so the sidebar ribbon icon is the primary
-    // visible entry point there. Default it on when the user hasn't made an explicit choice;
-    // an existing config that set it to false is left untouched.
-    if (this.app.isMobile && (data == null || data.workspaceSwitcherRibbon === undefined)) {
-      this.settings.workspaceSwitcherRibbon = true;
-    }
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, (await this.loadData()) as Partial<WorkspacesPlusSettings>);
   }
 
   async saveSettings() {
@@ -283,8 +276,11 @@ export default class WorkspacesPlus extends Plugin {
   }
 
   disableModesFeature() {
-    // On mobile the feature never wires anything up (see modesEnabled) -- nothing to tear down.
-    if (this.app.isMobile) return;
+    // Only undo what enableModesFeature() actually set up. It no-ops unless modesEnabled
+    // (so it never runs on mobile), and statusBarMode is the marker it leaves behind.
+    // Without this, toggling the persisted `workspaceSettings` off while the feature was
+    // never active would run applySettings() over an empty globalSettings and wipe app.json.
+    if (!this.statusBarMode) return;
     this.app.vault.off("config-changed", this.onConfigChange);
     let combinedSettings = this.mergeGlobalSettings();
     this.applySettings(combinedSettings);
@@ -509,10 +505,6 @@ export default class WorkspacesPlus extends Plugin {
   };
 
   needsReload(settings: Record<string, unknown>) {
-    // Mobile has no legacy editor -- Live Preview is always the active editor there, the
-    // CM6-loaded probe below (editor:toggle-source) doesn't apply, and a hard
-    // window.location.reload() mid-session is jarring. Never take the reload path on mobile.
-    if (this.app.isMobile) return false;
     return this.settings.reloadLivePreview && settings.livePreview != this.app.vault.config.livePreview;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -491,6 +491,10 @@ export default class WorkspacesPlus extends Plugin {
   };
 
   needsReload(settings: Record<string, unknown>) {
+    // Mobile has no legacy editor -- Live Preview is always the active editor there, the
+    // CM6-loaded probe below (editor:toggle-source) doesn't apply, and a hard
+    // window.location.reload() mid-session is jarring. Never take the reload path on mobile.
+    if (this.app.isMobile) return false;
     return this.settings.reloadLivePreview && settings.livePreview != this.app.vault.config.livePreview;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,7 +74,7 @@ export default class WorkspacesPlus extends Plugin {
       // a synchronous workspace-load that reads globalSettings back via mergeGlobalSettings();
       // if globalSettings were still empty at that point, applySettings() would overwrite (and
       // persist) an empty app.vault.config.
-      if (this.settings.workspaceSettings) this.storeGlobalSettings();
+      if (this.modesEnabled) this.storeGlobalSettings();
       this.setPlatformWorkspace();
 
       this.backupCoreConfig();
@@ -83,12 +83,12 @@ export default class WorkspacesPlus extends Plugin {
         this.registerWorkspaceHotkeys();
         this.setWorkspaceAttribute();
         this.addStatusBarIndicator.apply(this);
-        if (this.settings.workspaceSettings) this.enableModesFeature();
+        if (this.modesEnabled) this.enableModesFeature();
         if (this.settings.workspaceSwitcherRibbon) {
           this.toggleWorkspaceRibbonButton();
           this.toggleNativeWorkspaceRibbon();
         }
-        if (this.settings.workspaceSettings && this.settings.modeSwitcherRibbon) {
+        if (this.modesEnabled && this.settings.modeSwitcherRibbon) {
           this.toggleModeRibbonButton();
         }
       }, 100);
@@ -112,7 +112,7 @@ export default class WorkspacesPlus extends Plugin {
   }
 
   onunload(): void {
-    if (this.settings.workspaceSettings) {
+    if (this.modesEnabled) {
       let combinedSettings = this.mergeGlobalSettings();
       this.applySettings(combinedSettings);
     }
@@ -183,6 +183,15 @@ export default class WorkspacesPlus extends Plugin {
     this.registerEvent(this.app.workspace.on("resize", this.onLayoutChange));
   }
 
+  // Modes snapshot and restore Obsidian's entire core config (app.json, which is shared
+  // across platforms). applySettings() replaces app.vault.config wholesale, so restoring a
+  // desktop-captured snapshot on mobile would drop mobile-only keys (mobile toolbar, pull
+  // action, etc.) and persist the loss. Until Modes captures/merges config platform-safely,
+  // the feature is desktop-only regardless of the stored toggle.
+  get modesEnabled(): boolean {
+    return this.settings.workspaceSettings && !this.app.isMobile;
+  }
+
   get changeWorkspaceButton() {
     return this.statusBarWorkspace?.querySelector(".status-bar-item-segment.name");
   }
@@ -240,7 +249,7 @@ export default class WorkspacesPlus extends Plugin {
     }
   }
   toggleModeRibbonButton(): void {
-    if (this.settings.workspaceSettings && this.settings.modeSwitcherRibbon) {
+    if (this.modesEnabled && this.settings.modeSwitcherRibbon) {
       if (!this.ribbonIconMode) {
         this.ribbonIconMode = this.addRibbonIcon("gear", "Manage modes", async () =>
           new WorkspacesPlusPluginModeModal(this, this.settings, true).open()
@@ -253,7 +262,7 @@ export default class WorkspacesPlus extends Plugin {
   }
 
   enableModesFeature() {
-    if (this.settings.workspaceSettings) {
+    if (this.modesEnabled) {
       this.storeGlobalSettings();
       this.addStatusBarIndicator("mode");
       this.addCommand({
@@ -274,6 +283,8 @@ export default class WorkspacesPlus extends Plugin {
   }
 
   disableModesFeature() {
+    // On mobile the feature never wires anything up (see modesEnabled) -- nothing to tear down.
+    if (this.app.isMobile) return;
     this.app.vault.off("config-changed", this.onConfigChange);
     let combinedSettings = this.mergeGlobalSettings();
     this.applySettings(combinedSettings);
@@ -331,7 +342,7 @@ export default class WorkspacesPlus extends Plugin {
       } else {
         this.changeWorkspaceButton?.setText(this.utils.activeWorkspace);
       }
-      if (this.settings.workspaceSettings) this.changeModeButton?.setText(this.utils.getActiveModeDisplayName());
+      if (this.modesEnabled) this.changeModeButton?.setText(this.utils.getActiveModeDisplayName());
     },
     100,
     true
@@ -353,7 +364,7 @@ export default class WorkspacesPlus extends Plugin {
   );
 
   onConfigChange = () => {
-    if (!this.settings.workspaceSettings) return;
+    if (!this.modesEnabled) return;
     if (this.workspaceLoading) {
       if (this.debug) console.debug("skipped save due to recent workspace switch");
       return;
@@ -380,7 +391,7 @@ export default class WorkspacesPlus extends Plugin {
   setWorkspaceAttribute() {
     const workspace = this.utils.activeWorkspace;
     document.body.dataset.workspaceName = workspace;
-    if (this.settings.workspaceSettings) {
+    if (this.modesEnabled) {
       const modeName = this.utils.getActiveModeDisplayName();
       if (modeName) document.body.dataset.workspaceMode = modeName;
     }
@@ -445,7 +456,7 @@ export default class WorkspacesPlus extends Plugin {
       }
     }
     
-    if (this.settings.workspaceSettings && this.utils.isMode(workspaceName)) {
+    if (this.modesEnabled && this.utils.isMode(workspaceName)) {
       customSettings.app = this.app.vault.config;
     }
     
@@ -476,7 +487,7 @@ export default class WorkspacesPlus extends Plugin {
     this.setWorkspaceAttribute(); // sets HTML data attribute
     this.updatePlatformWorkspace(name);
     const settings = this.utils.getWorkspaceSettings(name);
-    if (this.settings.workspaceSettings) {
+    if (this.modesEnabled) {
       const modeName = settings?.mode;
       const mode = modeName && this.utils.getModeSettings(modeName);
       let combinedSettings;
@@ -609,7 +620,7 @@ export default class WorkspacesPlus extends Plugin {
             plugin.setLoadingStatus();
             let result;
             
-            if (plugin.settings.workspaceSettings && plugin.utils.isMode(workspaceName)) {
+            if (plugin.modesEnabled && plugin.utils.isMode(workspaceName)) {
               // if the workspace being loaded is a mode, invoke the mode loader
               let modeName = workspaceName;
               workspaceName = plugin.utils.activeWorkspace;

--- a/src/modeModal.ts
+++ b/src/modeModal.ts
@@ -34,8 +34,9 @@ export class WorkspacesPlusPluginModeModal extends FuzzySuggestModal<string> {
 
     this.modalEl.classList.add("workspaces-plus-mode-modal");
 
-    // handle custom modal positioning when invoked via the status bar
-    if (!this.invokedViaHotkey) {
+    // handle custom modal positioning when invoked via the status bar (desktop only --
+    // the status bar is hidden on mobile, so there is no anchor to position against)
+    if (!this.invokedViaHotkey && !this.app.isMobile) {
       this.bgEl.addClass("workspaces-plus-transparent-bg");
       this.modalEl.classList.add("quick-switch");
     }
@@ -84,6 +85,8 @@ export class WorkspacesPlusPluginModeModal extends FuzzySuggestModal<string> {
   }
 
   buildInstructions(): void {
+    // Touch devices have no modifier-key shortcuts to advertise.
+    if (this.app.isMobile) return;
     if (this.settings.showInstructions || this.invokedViaHotkey) {
       let instructions;
       instructions = [
@@ -144,7 +147,7 @@ export class WorkspacesPlusPluginModeModal extends FuzzySuggestModal<string> {
   open(): void {
     this.app.keymap.pushScope(this.scope);
     document.body.appendChild(this.containerEl);
-    if (!this.invokedViaHotkey) {
+    if (!this.invokedViaHotkey && !this.app.isMobile) {
       this.popper = createPopper(document.body.querySelector(".plugin-workspaces-plus.mode-switcher"), this.modalEl, {
         placement: "top-start",
         modifiers: [{ name: "offset", options: { offset: [0, 10] } }],

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -183,15 +183,17 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
         })
       );
 
-    new Setting(containerEl)
-      .setName(TOGGLE_TEXT.modeSwitcherRibbon.name)
-      .addToggle(toggle =>
-        toggle.setValue(this.plugin.settings.modeSwitcherRibbon).onChange(value => {
-          this.plugin.settings.modeSwitcherRibbon = value;
-          void this.plugin.saveData(this.plugin.settings);
-          this.plugin.toggleModeRibbonButton();
-        })
-      );
+    if (!this.plugin.app.isMobile) {
+      new Setting(containerEl)
+        .setName(TOGGLE_TEXT.modeSwitcherRibbon.name)
+        .addToggle(toggle =>
+          toggle.setValue(this.plugin.settings.modeSwitcherRibbon).onChange(value => {
+            this.plugin.settings.modeSwitcherRibbon = value;
+            void this.plugin.saveData(this.plugin.settings);
+            this.plugin.toggleModeRibbonButton();
+          })
+        );
+    }
 
     new Setting(containerEl).setName("Workspace enhancements").setHeading();
 
@@ -205,12 +207,16 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
           });
         })
       )
-      .setDesc(TOGGLE_TEXT.workspaceSettings.desc)
+      .setDesc(
+        this.plugin.app.isMobile
+          ? "Workspace modes are desktop only -- they snapshot and restore Obsidian's core config, which is shared with mobile and would overwrite mobile-specific settings. Plain workspace switching works normally on mobile."
+          : TOGGLE_TEXT.workspaceSettings.desc
+      )
       .then(setting => {
         setting.settingEl.addClass("workspace-modes");
-        if (this.plugin.settings.workspaceSettings) setting.settingEl.addClass("is-enabled");
+        if (this.plugin.settings.workspaceSettings && !this.plugin.app.isMobile) setting.settingEl.addClass("is-enabled");
         else setting.settingEl.removeClass("is-enabled");
-        setting.addToggle(toggle =>
+        setting.addToggle(toggle => {
           toggle.setValue(this.plugin.settings.workspaceSettings).onChange(value => {
             if (value) setting.settingEl.addClass("is-enabled");
             else setting.settingEl.removeClass("is-enabled");
@@ -218,8 +224,9 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
             void this.plugin.saveData(this.plugin.settings);
             if (value) this.plugin.enableModesFeature();
             else this.plugin.disableModesFeature();
-          })
-        );
+          });
+          if (this.plugin.app.isMobile) toggle.setDisabled(true);
+        });
       });
 
     new Setting(containerEl)

--- a/src/workspaceModal.ts
+++ b/src/workspaceModal.ts
@@ -34,8 +34,9 @@ export class WorkspacesPlusPluginWorkspaceModal extends FuzzySuggestModal<string
 
     this.modalEl.classList.add("workspaces-plus-modal");
 
-    // handle custom modal positioning when invoked via the status bar
-    if (!this.invokedViaHotkey) {
+    // handle custom modal positioning when invoked via the status bar (desktop only --
+    // the status bar is hidden on mobile, so there is no anchor to position against)
+    if (!this.invokedViaHotkey && !this.app.isMobile) {
       this.bgEl.addClass("workspaces-plus-transparent-bg");
       this.modalEl.classList.add("quick-switch");
     }
@@ -84,6 +85,8 @@ export class WorkspacesPlusPluginWorkspaceModal extends FuzzySuggestModal<string
   }
 
   buildInstructions(): void {
+    // Touch devices have no modifier-key shortcuts to advertise.
+    if (this.app.isMobile) return;
     if (this.settings.showInstructions || this.invokedViaHotkey) {
       let instructions;
       if (!this.settings.saveOnChange) {
@@ -159,7 +162,7 @@ export class WorkspacesPlusPluginWorkspaceModal extends FuzzySuggestModal<string
   open(): void {
     this.app.keymap.pushScope(this.scope);
     document.body.appendChild(this.containerEl);
-    if (!this.invokedViaHotkey) {
+    if (!this.invokedViaHotkey && !this.app.isMobile) {
       this.popper = createPopper(document.body.querySelector(".plugin-workspaces-plus"), this.modalEl, {
         placement: "top-start",
         modifiers: [{ name: "offset", options: { offset: [0, 10] } }],

--- a/styles.css
+++ b/styles.css
@@ -120,6 +120,45 @@ body.is-mobile .prompt-results:not(.renaming) .workspace-item ~ .platform {
   opacity: 1;
 }
 
+/* Mobile: no hover, so give the always-visible row actions real touch targets
+   and space them apart. Extra right padding on the row/description keeps the
+   workspace name clear of the enlarged icons. */
+body.is-mobile .workspace-item {
+  padding-top: 11px;
+  padding-bottom: 11px;
+  padding-right: 8.5rem;
+}
+
+body.is-mobile .workspace-results .workspace-description {
+  padding-right: 8.5rem;
+}
+
+body.is-mobile .workspace-results .rename-workspace,
+body.is-mobile .workspace-results .delete-workspace,
+body.is-mobile .workspace-results .platform {
+  padding: 7px;
+  margin-top: 0.15em;
+}
+
+body.is-mobile .workspace-results .delete-workspace {
+  right: 0.15em;
+}
+
+body.is-mobile .workspace-results .rename-workspace {
+  right: 2.7em;
+}
+
+body.is-mobile .workspace-results .platform {
+  right: 5.25em;
+}
+
+body.is-mobile .workspace-results .rename-workspace svg,
+body.is-mobile .workspace-results .delete-workspace svg,
+body.is-mobile .workspace-results .platform svg {
+  width: 20px;
+  height: 20px;
+}
+
 .workspace-item {
   display: inline-block;
   width: 100%;

--- a/tests/mobileGating.test.js
+++ b/tests/mobileGating.test.js
@@ -2,9 +2,10 @@
 //
 // main.ts can't be imported directly (it pulls in `obsidian`, popper, moment, ...),
 // so we transpile it and run it with a custom `require` that returns minimal stubs.
-// We only exercise pure decision logic -- the `modesEnabled` getter and
-// `loadSettings()` -- via Object.create(prototype), so the Plugin constructor and
-// the debounce()-based field initializers never run.
+// We exercise pure decision logic via Object.create(prototype), so the Plugin
+// constructor and the debounce()-based field initializers never run:
+//   - `modesEnabled` getter: desktop parity, forced off on mobile
+//   - `loadSettings()`: identical on both platforms, no per-platform mutation
 
 const assert = require("assert");
 const fs = require("fs");
@@ -104,43 +105,36 @@ const loadWith = async (isMobile, savedData) => {
     assert.strictEqual(p.modesEnabled, false);
   });
 
-  // --- loadSettings ---------------------------------------------------
+  // --- loadSettings: identical on both platforms, no per-platform mutation ---
   console.log("loadSettings");
 
-  await check("desktop + no saved data -> exactly DEFAULT_SETTINGS", async () => {
-    assert.deepStrictEqual(await loadWith(false, null), DEFAULT_SETTINGS);
-  });
+  for (const isMobile of [false, true]) {
+    const plat = isMobile ? "mobile" : "desktop";
 
-  await check("desktop + saved overrides -> merged over defaults, ribbon untouched", async () => {
-    const s = await loadWith(false, { saveOnChange: true, activeWorkspaceDesktop: "Work" });
-    assert.strictEqual(s.saveOnChange, true);
-    assert.strictEqual(s.activeWorkspaceDesktop, "Work");
-    assert.strictEqual(s.workspaceSwitcherRibbon, false);
-    assert.strictEqual(s.showInstructions, true); // default preserved
-  });
+    await check(`${plat} + no saved data -> exactly DEFAULT_SETTINGS`, async () => {
+      assert.deepStrictEqual(await loadWith(isMobile, null), DEFAULT_SETTINGS);
+    });
 
-  await check("desktop never forces the ribbon on, even with no saved data", async () => {
-    assert.strictEqual((await loadWith(false, null)).workspaceSwitcherRibbon, false);
-  });
+    await check(`${plat} + saved overrides -> merged over defaults`, async () => {
+      const s = await loadWith(isMobile, { saveOnChange: true, activeWorkspaceDesktop: "Work" });
+      assert.strictEqual(s.saveOnChange, true);
+      assert.strictEqual(s.activeWorkspaceDesktop, "Work");
+      assert.strictEqual(s.showInstructions, true); // untouched default preserved
+    });
 
-  await check("mobile + no saved data -> ribbon defaulted on", async () => {
-    assert.strictEqual((await loadWith(true, null)).workspaceSwitcherRibbon, true);
-  });
+    await check(`${plat} never forces workspaceSwitcherRibbon on`, async () => {
+      assert.strictEqual((await loadWith(isMobile, null)).workspaceSwitcherRibbon, false);
+      assert.strictEqual((await loadWith(isMobile, {})).workspaceSwitcherRibbon, false);
+    });
 
-  await check("mobile + saved data without the key -> ribbon defaulted on", async () => {
-    assert.strictEqual((await loadWith(true, { saveOnChange: true })).workspaceSwitcherRibbon, true);
-  });
-
-  await check("mobile + saved ribbon:false -> left as-is (no override)", async () => {
-    assert.strictEqual((await loadWith(true, { workspaceSwitcherRibbon: false })).workspaceSwitcherRibbon, false);
-  });
-
-  await check("mobile + saved ribbon:true -> stays on", async () => {
-    assert.strictEqual((await loadWith(true, { workspaceSwitcherRibbon: true })).workspaceSwitcherRibbon, true);
-  });
+    await check(`${plat} + saved ribbon value -> respected verbatim`, async () => {
+      assert.strictEqual((await loadWith(isMobile, { workspaceSwitcherRibbon: true })).workspaceSwitcherRibbon, true);
+      assert.strictEqual((await loadWith(isMobile, { workspaceSwitcherRibbon: false })).workspaceSwitcherRibbon, false);
+    });
+  }
 
   await check("loadSettings never mutates DEFAULT_SETTINGS", async () => {
-    await loadWith(true, null);
+    await loadWith(true, { workspaceSwitcherRibbon: true });
     assert.strictEqual(DEFAULT_SETTINGS.workspaceSwitcherRibbon, false);
   });
 

--- a/tests/mobileGating.test.js
+++ b/tests/mobileGating.test.js
@@ -1,0 +1,152 @@
+// Regression coverage for the mobile-support changes on `feat/mobile-support`.
+//
+// main.ts can't be imported directly (it pulls in `obsidian`, popper, moment, ...),
+// so we transpile it and run it with a custom `require` that returns minimal stubs.
+// We only exercise pure decision logic -- the `modesEnabled` getter and
+// `loadSettings()` -- via Object.create(prototype), so the Plugin constructor and
+// the debounce()-based field initializers never run.
+
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+
+// --- real DEFAULT_SETTINGS (kept in sync with src/settings.ts) ---------------
+const DEFAULT_SETTINGS = {
+  showInstructions: true,
+  showDeletePrompt: true,
+  saveOnSwitch: false,
+  saveOnChange: false,
+  workspaceSettings: false,
+  systemDarkMode: false,
+  globalSettings: {},
+  activeWorkspaceDesktop: "",
+  activeWorkspaceMobile: "",
+  reloadLivePreview: false,
+  workspaceSwitcherRibbon: false,
+  modeSwitcherRibbon: false,
+  replaceNativeRibbon: false,
+  trackOpenFiles: true,
+  restoreLayoutOnStartup: false,
+};
+
+// --- load main.ts with stubbed imports -------------------------------------
+const source = fs.readFileSync(path.join(__dirname, "../src/main.ts"), "utf8");
+const output = ts.transpileModule(source, {
+  compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 },
+}).outputText;
+
+const noop = () => {};
+const stubs = {
+  obsidian: { Plugin: class {}, setIcon: noop, Notice: class {}, debounce: fn => fn },
+  "./settings": { DEFAULT_SETTINGS, WorkspacesPlusSettingsTab: class {} },
+  "./workspaceModal": { WorkspacesPlusPluginWorkspaceModal: class {} },
+  "./modeModal": { WorkspacesPlusPluginModeModal: class {} },
+  "./utils": { default: class {} },
+  "monkey-around": { around: () => noop },
+  "./workspaceCycle": { cycleWorkspace: noop },
+};
+const fakeRequire = id => {
+  if (id in stubs) return stubs[id];
+  throw new Error(`unexpected require("${id}") in main.ts test harness`);
+};
+const compiled = { exports: {} };
+new Function("require", "module", "exports", output)(fakeRequire, compiled, compiled.exports);
+const WorkspacesPlus = compiled.exports.default;
+assert.ok(WorkspacesPlus, "expected main.ts to default-export the plugin class");
+
+const make = () => Object.create(WorkspacesPlus.prototype);
+
+let passed = 0;
+const check = async (label, fn) => {
+  await fn();
+  passed++;
+  console.log(`  ok  ${label}`);
+};
+
+const loadWith = async (isMobile, savedData) => {
+  const p = make();
+  p.app = { isMobile };
+  p.loadData = async () => savedData;
+  await p.loadSettings();
+  return p.settings;
+};
+
+(async () => {
+  // --- modesEnabled: desktop parity + mobile gating ---------------------
+  console.log("modesEnabled");
+
+  await check("desktop + modes on  -> true (parity with settings.workspaceSettings)", () => {
+    const p = make();
+    p.app = { isMobile: false };
+    p.settings = { workspaceSettings: true };
+    assert.strictEqual(p.modesEnabled, true);
+  });
+
+  await check("desktop + modes off -> false", () => {
+    const p = make();
+    p.app = { isMobile: false };
+    p.settings = { workspaceSettings: false };
+    assert.strictEqual(p.modesEnabled, false);
+  });
+
+  await check("mobile + modes on   -> false (feature gated off on mobile)", () => {
+    const p = make();
+    p.app = { isMobile: true };
+    p.settings = { workspaceSettings: true };
+    assert.strictEqual(p.modesEnabled, false);
+  });
+
+  await check("mobile + modes off  -> false", () => {
+    const p = make();
+    p.app = { isMobile: true };
+    p.settings = { workspaceSettings: false };
+    assert.strictEqual(p.modesEnabled, false);
+  });
+
+  // --- loadSettings ---------------------------------------------------
+  console.log("loadSettings");
+
+  await check("desktop + no saved data -> exactly DEFAULT_SETTINGS", async () => {
+    assert.deepStrictEqual(await loadWith(false, null), DEFAULT_SETTINGS);
+  });
+
+  await check("desktop + saved overrides -> merged over defaults, ribbon untouched", async () => {
+    const s = await loadWith(false, { saveOnChange: true, activeWorkspaceDesktop: "Work" });
+    assert.strictEqual(s.saveOnChange, true);
+    assert.strictEqual(s.activeWorkspaceDesktop, "Work");
+    assert.strictEqual(s.workspaceSwitcherRibbon, false);
+    assert.strictEqual(s.showInstructions, true); // default preserved
+  });
+
+  await check("desktop never forces the ribbon on, even with no saved data", async () => {
+    assert.strictEqual((await loadWith(false, null)).workspaceSwitcherRibbon, false);
+  });
+
+  await check("mobile + no saved data -> ribbon defaulted on", async () => {
+    assert.strictEqual((await loadWith(true, null)).workspaceSwitcherRibbon, true);
+  });
+
+  await check("mobile + saved data without the key -> ribbon defaulted on", async () => {
+    assert.strictEqual((await loadWith(true, { saveOnChange: true })).workspaceSwitcherRibbon, true);
+  });
+
+  await check("mobile + saved ribbon:false -> left as-is (no override)", async () => {
+    assert.strictEqual((await loadWith(true, { workspaceSwitcherRibbon: false })).workspaceSwitcherRibbon, false);
+  });
+
+  await check("mobile + saved ribbon:true -> stays on", async () => {
+    assert.strictEqual((await loadWith(true, { workspaceSwitcherRibbon: true })).workspaceSwitcherRibbon, true);
+  });
+
+  await check("loadSettings never mutates DEFAULT_SETTINGS", async () => {
+    await loadWith(true, null);
+    assert.strictEqual(DEFAULT_SETTINGS.workspaceSwitcherRibbon, false);
+  });
+
+  console.log(`\n${passed} checks passed`);
+})().catch(err => {
+  console.error(`\nFAILED after ${passed} checks:`);
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #128

Enables Workspaces Plus on Obsidian mobile (phone and tablet) by flipping `isDesktopOnly` to `false`, plus the guarding and UX work that makes it behave there.

## What changed

- **`isDesktopOnly: false`** in `manifest.json` / `manifest-beta.json`. The codebase already uses zero Node/Electron APIs.
- **Live Preview reload path** stays desktop-only — it only runs inside a `modesEnabled` block (mobile has no legacy editor; a hard `window.location.reload()` mid-session is disruptive).
- **Workspace Modes is gated off on mobile.** Modes snapshot and restore Obsidian's core `app.json`, which is shared across platforms; a wholesale restore of a desktop-captured snapshot on mobile would drop mobile-only keys (mobile toolbar, pull action, tab modifier) and persist the loss. A new `modesEnabled` getter (`workspaceSettings && !app.isMobile`) routes every runtime Modes branch — startup wiring, workspace load/save, config-change autosave, body attributes, the `loadWorkspace` patch, unload restore. `enable/disableModesFeature` no-op when the feature was never wired up. The settings toggle still persists (shared with desktop) but renders disabled on mobile with an explanation; the mode-switcher ribbon toggle is hidden there.
- **Touch UX** for the switcher / mode modals: no status-bar anchor on mobile (it's hidden there, so `createPopper` had no anchor); the modifier-key instruction bar is skipped; row actions (rename / delete / platform) render always-visible with real touch targets via `body.is-mobile` CSS.
- **Entry point on mobile:** the status bar is hidden by default, so the always-registered **Open workspace switcher** command is the default entry point. The sidebar ribbon icon is off by default (same as desktop) and can be toggled on in settings.

## Not done here (needs a real device)

Switcher / mode modal layout on a phone vs. tablet, the ribbon icon in the mobile sidebar, and inline-rename with the soft keyboard. The desktop "Emulate mobile" developer toggle covers a first pass.

## Tests

`npm test` adds `tests/mobileGating.test.js` (13 checks): `modesEnabled` desktop parity + mobile gating, and `loadSettings` producing identical output on both platforms. Existing `workspaceCycle` test unaffected. `npm run build` and `npx eslint src/` clean (3 pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)