### PR TITLE
fix: don't delete workspace when renaming without changing the name

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "rollup --config rollup.config.js -w",
     "build": "rollup --config rollup.config.js --environment BUILD:production",
-    "test": "node tests/workspaceCycle.test.js && node tests/mobileGating.test.js",
+    "test": "node tests/workspaceCycle.test.js && node tests/mobileGating.test.js && node tests/renameWorkspace.test.js",
     "lint": "eslint .",
     "release": "auto shipit"
   },

--- a/src/modeModal.ts
+++ b/src/modeModal.ts
@@ -173,8 +173,18 @@ export class WorkspacesPlusPluginModeModal extends FuzzySuggestModal<string> {
   handleRename(targetEl: HTMLElement): void {
     // TODO: Update all workspaces on mode rename
     targetEl.parentElement.parentElement.removeClass("renaming");
-    const originalName = "Mode: " + targetEl.dataset.workspaceName;
-    const newName = "Mode: " + targetEl.textContent;
+    const originalBareName = targetEl.dataset.workspaceName;
+    const newBareName = targetEl.textContent?.trim();
+    // Bail out if the name is empty or unchanged. Without this guard, an unchanged
+    // rename does `workspaces[name] = workspaces[name]` (a no-op) and then
+    // `delete workspaces[name]`, wiping the mode. See issue #69.
+    if (!newBareName || newBareName === originalBareName) {
+      targetEl.textContent = originalBareName;
+      targetEl.contentEditable = "false";
+      return;
+    }
+    const originalName = "Mode: " + originalBareName;
+    const newName = "Mode: " + newBareName;
     // let settings = this.workspacePlugin.workspaces[this.workspacePlugin.activeWorkspace][SETTINGS_ATTR];
     // let currentMode = settings["mode"] ? settings["mode"] : null;
     for (const workspace of Object.values(this.workspacePlugin.workspaces)) {

--- a/src/workspaceModal.ts
+++ b/src/workspaceModal.ts
@@ -188,7 +188,15 @@ export class WorkspacesPlusPluginWorkspaceModal extends FuzzySuggestModal<string
   handleRename(targetEl: HTMLElement): void {
     targetEl.parentElement.parentElement.removeClass("renaming");
     const originalName = targetEl.dataset.workspaceName;
-    const newName = targetEl.textContent;
+    const newName = targetEl.textContent?.trim();
+    // Bail out if the name is empty or unchanged. Without this guard, an unchanged
+    // rename does `workspaces[name] = workspaces[name]` (a no-op) and then
+    // `delete workspaces[name]`, wiping the workspace. See issue #69.
+    if (!newName || newName === originalName) {
+      targetEl.textContent = originalName;
+      targetEl.contentEditable = "false";
+      return;
+    }
     this.workspacePlugin.workspaces[newName] = this.workspacePlugin.workspaces[originalName];
     delete this.workspacePlugin.workspaces[originalName];
     if (originalName === this.activeWorkspace) {

--- a/tests/renameWorkspace.test.js
+++ b/tests/renameWorkspace.test.js
@@ -1,0 +1,173 @@
+// Regression coverage for issue #69:
+// "Clicking enter while in the rename workspace input field, without having
+//  changed the workspace name, removes the workspace from the list"
+//
+// Root cause was in handleRename() (workspaceModal.ts / modeModal.ts): with an
+// unchanged name it ran `workspaces[name] = workspaces[name]` (a no-op) and then
+// `delete workspaces[name]`, wiping the workspace, after which onWorkspaceRename
+// persisted the loss to disk.
+//
+// Neither modal file can be imported directly (they pull in `obsidian`, popper,
+// ...), so we transpile them and run with a custom `require` that returns minimal
+// stubs, then exercise handleRename() via Object.create(prototype) so the
+// FuzzySuggestModal constructor never runs.
+
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+
+// --- load a modal file with stubbed imports --------------------------------
+const noop = () => {};
+const stubs = {
+  obsidian: { FuzzySuggestModal: class {}, Notice: class {}, Scope: class {}, setIcon: noop },
+  "@popperjs/core": { createPopper: noop },
+  "./settings": {},
+  "./confirm": { createConfirmationDialog: noop },
+  "./main": { default: class {} },
+};
+const fakeRequire = id => {
+  if (id in stubs) return stubs[id];
+  throw new Error(`unexpected require("${id}") in rename test harness`);
+};
+const loadModal = (file, exportName) => {
+  const source = fs.readFileSync(path.join(__dirname, "..", "src", file), "utf8");
+  const output = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 },
+  }).outputText;
+  const compiled = { exports: {} };
+  new Function("require", "module", "exports", output)(fakeRequire, compiled, compiled.exports);
+  const cls = compiled.exports[exportName];
+  assert.ok(cls, `expected ${file} to export ${exportName}`);
+  return cls;
+};
+
+const WorkspaceModal = loadModal("workspaceModal.ts", "WorkspacesPlusPluginWorkspaceModal");
+const ModeModal = loadModal("modeModal.ts", "WorkspacesPlusPluginModeModal");
+
+// --- test doubles ---------------------------------------------------------
+const makeTargetEl = (workspaceName, typedText) => ({
+  dataset: { workspaceName },
+  textContent: typedText === undefined ? workspaceName : typedText,
+  contentEditable: "true",
+  parentElement: { parentElement: { removeClass: noop } },
+});
+
+const makeModal = (Cls, workspaces, activeWorkspace) => {
+  const modal = Object.create(Cls.prototype);
+  const renameEvents = [];
+  modal.workspacePlugin = { workspaces };
+  modal.activeWorkspace = activeWorkspace;
+  modal.setWorkspace = name => renameEvents.push(`setWorkspace:${name}`);
+  modal.chooser = {
+    chooser: { updateSuggestions: noop },
+    setSelectedItem: noop,
+  };
+  modal.app = {
+    workspace: {
+      trigger: (evt, ...args) => renameEvents.push(`${evt}:${args.join("->")}`),
+    },
+  };
+  modal.renameEvents = renameEvents;
+  return modal;
+};
+
+let passed = 0;
+const check = (label, fn) => {
+  fn();
+  passed++;
+  console.log(`  ok  ${label}`);
+};
+
+// --- workspace modal ----------------------------------------------------
+console.log("workspaceModal.handleRename");
+
+check("unchanged name is a no-op and keeps the workspace (issue #69)", () => {
+  const workspaces = { Work: { id: "w" }, Home: { id: "h" } };
+  const modal = makeModal(WorkspaceModal, workspaces, "Home");
+  const el = makeTargetEl("Work"); // pencil-icon rename, nothing typed
+
+  modal.handleRename(el);
+
+  assert.deepStrictEqual(Object.keys(workspaces).sort(), ["Home", "Work"]);
+  assert.deepStrictEqual(workspaces.Work, { id: "w" });
+  assert.strictEqual(el.contentEditable, "false");
+  assert.deepStrictEqual(modal.renameEvents, [], "no workspace-rename should be triggered");
+});
+
+check("whitespace-only name is a no-op and keeps the workspace", () => {
+  const workspaces = { Work: { id: "w" } };
+  const modal = makeModal(WorkspaceModal, workspaces, "Work");
+  const el = makeTargetEl("Work", "   ");
+
+  modal.handleRename(el);
+
+  assert.deepStrictEqual(Object.keys(workspaces), ["Work"]);
+  assert.strictEqual(el.textContent, "Work", "field is reverted to the original name");
+  assert.strictEqual(el.contentEditable, "false");
+  assert.deepStrictEqual(modal.renameEvents, []);
+});
+
+check("changed name still renames the workspace", () => {
+  const workspaces = { Work: { id: "w" }, Home: { id: "h" } };
+  const modal = makeModal(WorkspaceModal, workspaces, "Home");
+  const el = makeTargetEl("Work", "Office");
+
+  modal.handleRename(el);
+
+  assert.deepStrictEqual(Object.keys(workspaces).sort(), ["Home", "Office"]);
+  assert.deepStrictEqual(workspaces.Office, { id: "w" });
+  assert.strictEqual(workspaces.Work, undefined);
+  assert.strictEqual(el.contentEditable, "false");
+  assert.deepStrictEqual(modal.renameEvents, ["workspace-rename:Office->Work"]);
+});
+
+check("changed name is trimmed before renaming", () => {
+  const workspaces = { Work: { id: "w" } };
+  const modal = makeModal(WorkspaceModal, workspaces, "Work");
+  const el = makeTargetEl("Work", "  Office  ");
+
+  modal.handleRename(el);
+
+  assert.deepStrictEqual(Object.keys(workspaces), ["Office"]);
+  assert.strictEqual(modal.activeWorkspace, "Office");
+});
+
+// --- mode modal -------------------------------------------------------
+console.log("modeModal.handleRename");
+
+check("unchanged mode name is a no-op and keeps the mode (issue #69)", () => {
+  const workspaces = { "Mode: Focus": { id: "f" }, "Mode: Chill": { id: "c" } };
+  const modal = makeModal(ModeModal, workspaces, "Mode: Chill");
+  const el = makeTargetEl("Focus");
+
+  modal.handleRename(el);
+
+  assert.deepStrictEqual(Object.keys(workspaces).sort(), ["Mode: Chill", "Mode: Focus"]);
+  assert.deepStrictEqual(workspaces["Mode: Focus"], { id: "f" });
+  assert.strictEqual(el.contentEditable, "false");
+  assert.deepStrictEqual(modal.renameEvents, []);
+});
+
+check("changed mode name still renames the mode", () => {
+  const workspaces = {
+    "Mode: Focus": { id: "f" },
+    Work: { "workspaces-plus:settings-v1": { mode: "Mode: Focus" } },
+  };
+  const modal = makeModal(ModeModal, workspaces, "Mode: Nope");
+  const el = makeTargetEl("Focus", "Deep Work");
+
+  modal.handleRename(el);
+
+  assert.deepStrictEqual(Object.keys(workspaces).sort(), ["Mode: Deep Work", "Work"]);
+  assert.deepStrictEqual(workspaces["Mode: Deep Work"], { id: "f" });
+  assert.strictEqual(workspaces["Mode: Focus"], undefined);
+  assert.strictEqual(
+    workspaces.Work["workspaces-plus:settings-v1"].mode,
+    "Mode: Deep Work",
+    "referencing workspaces are repointed at the new mode name"
+  );
+  assert.deepStrictEqual(modal.renameEvents, ["workspace-rename:Mode: Deep Work->Mode: Focus"]);
+});
+
+console.log(`\n${passed} checks passed`);


### PR DESCRIPTION
## Problem

`handleRename()` (in both `workspaceModal.ts` and `modeModal.ts`) built the new name from the contenteditable row and then ran:

```js
this.workspacePlugin.workspaces[newName] = this.workspacePlugin.workspaces[originalName];
delete this.workspacePlugin.workspaces[originalName];
```

When the name was **unchanged**, the assignment is a no-op self-assignment and the `delete` removes the only copy — the workspace vanishes from the list. `handleRename` then fires `workspace-rename`, which `onWorkspaceRename` handles by calling `this.workspacePlugin.saveData()`, so the loss is persisted to disk. An emptied field hit the same path with a `""` key.

Reproduction (from the issue): open the picker/switcher, click the pencil (or `Ctrl+Enter`), change nothing, press `Enter` → the workspace is removed.

## Fix

Both modals now bail out early when the edited name is empty/whitespace or equal to the original, reverting the field text and leaving `workspaces` untouched. A genuine rename also trims the new name.

## Tests

New `tests/renameWorkspace.test.js` (transpile-with-stubs pattern, same as `mobileGating.test.js`), wired into `npm test`:

- unchanged name → workspace/mode kept, no `workspace-rename` event (the issue #69 case)
- whitespace-only name → kept, field reverted
- changed name → still renames correctly; mode rename still repoints referencing workspaces
- new name is trimmed

Verified the new test fails against `master` (asserts the workspace was deleted) and passes with this fix. `npm test`, `npm run lint` (0 errors), and `npm run build` all pass.

Fixes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)