### PR TITLE
Isolate deferred-leaf loading so one bad leaf can't blank the sidebar on workspace switch

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -653,7 +653,22 @@ export default class WorkspacesPlus extends Plugin {
                     const leaves: WorkspaceLeaf[] = [];
                     this.app.workspace.iterateAllLeaves(leaf => leaves.push(leaf));
                     await Promise.all(
-                      leaves.filter(leaf => leaf.isDeferred).map(leaf => leaf.loadIfDeferred())
+                      leaves
+                        .filter(leaf => leaf.isDeferred)
+                        .map(leaf =>
+                          // Isolate each leaf. A leaf whose view type isn't registered
+                          // on this device -- e.g. a desktop-only plugin's view in a
+                          // layout opened on mobile/iPad -- rejects here, and an
+                          // unguarded Promise.all would then abort the whole restore:
+                          // saveData() is skipped and the sidebar / ribbon are left
+                          // half-rebuilt until the app is reloaded. Mirrors the
+                          // per-entry isolation in Utils.applyFileOverrides.
+                          Promise.resolve()
+                            .then(() => leaf.loadIfDeferred())
+                            .catch((e: unknown) => {
+                              console.error("failed to load deferred leaf:", e);
+                            })
+                        )
                     );
                     if (generation === plugin.workspaceLoadGeneration) this.saveData();
                   })


### PR DESCRIPTION
## Summary

Fixes the long‑standing "loading a workspace blanks the ribbon and left sidebar until I reload the app" report on iPad (#128, [comment](https://github.com/jsmorabito/obsidian-workspaces-plus/issues/128#issuecomment-5446174266)).

## Root cause

The `loadWorkspace` monkey‑patch force‑loads every deferred leaf after `changeLayout()`:

```ts
await Promise.all(
  leaves.filter(leaf => leaf.isDeferred).map(leaf => leaf.loadIfDeferred())
);
```

A saved layout opened on iPad/mobile routinely contains a leaf whose view type isn't registered there — a desktop‑only plugin, or one that simply isn't loaded on mobile. `loadIfDeferred()` for that leaf rejects, the **unguarded `Promise.all` rejects**, and the restore chain jumps straight to its `.catch`. `saveData()` never runs and the left drawer / ribbon are left half‑rebuilt until a full app reload — which works because Obsidian's own startup deserializer is fault‑tolerant.

## Fix

Wrap each `loadIfDeferred()` in its own `.catch` (through `Promise.resolve().then(...)` so a synchronous throw is caught too), exactly mirroring the per‑entry isolation already in `Utils.applyFileOverrides`. A leaf that can't load is logged and skipped; the rest of the switch — deferred loads, `saveData()`, the sidebar/ribbon rebuild — completes normally.

## Not covered

- If `changeLayout()` itself rejects on a malformed layout node the switch still fails; that's a separate, harder case and not what these reports describe.
- The Commander ribbon icons that also vanish in this scenario are a Commander‑side bug (it never re‑injected its ribbon icons after `changeLayout`); fixed separately in jsmorabito/obsidian-commander#205.

## Verification

- `npm run build` (rollup) — clean
- `npm test` — 19 checks pass
- `npm run lint` — no new findings (2 pre‑existing unrelated command‑ID warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
