### PR TITLE
Add ribbon-preservation option

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import {
   debounce,
   WorkspaceCustomSettings,
   WorkspaceLeaf,
+  Workspaces,
 } from "obsidian";
 import { WorkspacesPlusSettings, WorkspacesPlusSettingsTab, DEFAULT_SETTINGS } from "./settings";
 import { WorkspacesPlusPluginWorkspaceModal } from "./workspaceModal";
@@ -155,6 +156,22 @@ export default class WorkspacesPlus extends Plugin {
       name: "Save current workspace and cycle to next",
       callback: () => this.cycleWorkspace(true),
     });
+    this.addCommand({
+      id: "sync-ribbon-to-all-workspaces",
+      name: "Sync current ribbon layout to all workspaces",
+      callback: () => this.syncRibbonToAllWorkspaces(),
+    });
+  }
+
+  syncRibbonToAllWorkspaces(): void {
+    if (!this.isNativePluginEnabled) return;
+    const count = this.utils.syncRibbonAcrossWorkspaces();
+    if (count > 0) {
+      this.workspacePlugin.saveData();
+      new Notice(`Synced ribbon layout to ${count} workspaces.`);
+    } else {
+      new Notice("No ribbon layout detected to sync.");
+    }
   }
 
   cycleWorkspace(saveCurrent: boolean = false): void {
@@ -458,6 +475,10 @@ export default class WorkspacesPlus extends Plugin {
     
     let explorerFoldState: unknown = await this.app.loadLocalStorage("file-explorer-unfold");
     if (explorerFoldState) customSettings.explorerFoldState = explorerFoldState;
+
+    if (this.settings.preserveRibbon) {
+      this.utils.syncRibbonAcrossWorkspaces();
+    }
     
     this.workspacePlugin.saveData();
   };
@@ -611,6 +632,7 @@ export default class WorkspacesPlus extends Plugin {
             if (!workspaceName || !plugin.isNativePluginEnabled) return;
             plugin.setLoadingStatus();
             let result;
+            const currentLayoutBeforeSwitch = plugin.app.workspace.getLayout();
             
             if (plugin.modesEnabled && plugin.utils.isMode(workspaceName)) {
               // if the workspace being loaded is a mode, invoke the mode loader
@@ -644,7 +666,11 @@ export default class WorkspacesPlus extends Plugin {
                     // A newer switch started while restore was running -- applying this
                     // (now-stale) layout would revert the user's screen back to it.
                     if (generation !== plugin.workspaceLoadGeneration) return;
-                    await this.app.workspace.changeLayout(workspace);
+                    let layoutToApply: Workspaces = workspace;
+                    if (plugin.settings.preserveRibbon && currentLayoutBeforeSwitch) {
+                      layoutToApply = plugin.utils.preserveRibbonInLayout(workspace, currentLayoutBeforeSwitch);
+                    }
+                    await this.app.workspace.changeLayout(layoutToApply);
                     if (generation !== plugin.workspaceLoadGeneration) return;
                     // changeLayout() creates the leaves, but leaves in the background stay
                     // "deferred" (a lightweight placeholder) until focused. Force-load every

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,11 +166,13 @@ export default class WorkspacesPlus extends Plugin {
   syncRibbonToAllWorkspaces(): void {
     if (!this.isNativePluginEnabled) return;
     const count = this.utils.syncRibbonAcrossWorkspaces();
-    if (count > 0) {
+    if (count === null) {
+      new Notice("No ribbon layout detected to sync.");
+    } else if (count > 0) {
       this.workspacePlugin.saveData();
       new Notice(`Synced ribbon layout to ${count} workspaces.`);
     } else {
-      new Notice("No ribbon layout detected to sync.");
+      new Notice("No other workspaces to sync the ribbon layout to.");
     }
   }
 
@@ -632,8 +634,7 @@ export default class WorkspacesPlus extends Plugin {
             if (!workspaceName || !plugin.isNativePluginEnabled) return;
             plugin.setLoadingStatus();
             let result;
-            const currentLayoutBeforeSwitch = plugin.app.workspace.getLayout();
-            
+
             if (plugin.modesEnabled && plugin.utils.isMode(workspaceName)) {
               // if the workspace being loaded is a mode, invoke the mode loader
               let modeName = workspaceName;
@@ -666,9 +667,12 @@ export default class WorkspacesPlus extends Plugin {
                     // A newer switch started while restore was running -- applying this
                     // (now-stale) layout would revert the user's screen back to it.
                     if (generation !== plugin.workspaceLoadGeneration) return;
+                    // Captured here, right before use, rather than at the top of loadWorkspace --
+                    // the restore chain above can await real file I/O, and grabbing the ribbon
+                    // before that gap risks re-applying a snapshot the user has since changed.
                     let layoutToApply: Workspaces = workspace;
-                    if (plugin.settings.preserveRibbon && currentLayoutBeforeSwitch) {
-                      layoutToApply = plugin.utils.preserveRibbonInLayout(workspace, currentLayoutBeforeSwitch);
+                    if (plugin.settings.preserveRibbon) {
+                      layoutToApply = plugin.utils.preserveRibbonInLayout(workspace, plugin.app.workspace.getLayout());
                     }
                     await this.app.workspace.changeLayout(layoutToApply);
                     if (generation !== plugin.workspaceLoadGeneration) return;

--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -139,6 +139,7 @@ declare module "obsidian" {
     main?: WorkspaceLayoutNode;
     left?: WorkspaceLayoutNode;
     right?: WorkspaceLayoutNode;
+    "left-ribbon"?: unknown;
     active?: string;
     [x: string]: any; // includes the plugin's own settings key (workspaces-plus:settings-v1) and other internal/dynamic keys
   }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -45,6 +45,10 @@ export const TOGGLE_TEXT: Record<string, ToggleText> = {
       "This option will auto save your current workspace on any layout change. " +
       "Leave this disabled if you want full control over when your workspace is saved.",
   },
+  preserveRibbon: {
+    name: "Preserve ribbon icons across workspaces",
+    desc: "Keep the current left ribbon icons and their order when switching workspaces instead of loading each workspace's saved ribbon state.",
+  },
   trackOpenFiles: {
     name: "Automatically track and restore open files",
     desc:
@@ -86,6 +90,7 @@ export class WorkspacesPlusSettings {
   modeSwitcherRibbon: boolean;
   replaceNativeRibbon: boolean;
   trackOpenFiles: boolean;
+  preserveRibbon: boolean;
   restoreLayoutOnStartup: boolean;
 }
 
@@ -104,6 +109,7 @@ export const DEFAULT_SETTINGS: WorkspacesPlusSettings = {
   modeSwitcherRibbon: false,
   replaceNativeRibbon: false,
   trackOpenFiles: true,
+  preserveRibbon: false,
   restoreLayoutOnStartup: false,
 };
 
@@ -245,6 +251,16 @@ export class WorkspacesPlusSettingsTab extends PluginSettingTab {
       .addToggle(toggle =>
         toggle.setValue(this.plugin.settings.trackOpenFiles).onChange(value => {
           this.plugin.settings.trackOpenFiles = value;
+          void this.plugin.saveData(this.plugin.settings);
+        })
+      );
+
+    new Setting(containerEl)
+      .setName(TOGGLE_TEXT.preserveRibbon.name)
+      .setDesc(TOGGLE_TEXT.preserveRibbon.desc)
+      .addToggle(toggle =>
+        toggle.setValue(this.plugin.settings.preserveRibbon).onChange(value => {
+          this.plugin.settings.preserveRibbon = value;
           void this.plugin.saveData(this.plugin.settings);
         })
       );

--- a/src/settingsDeclarative.ts
+++ b/src/settingsDeclarative.ts
@@ -74,6 +74,11 @@ export function getSettingDefinitions(tab: WorkspacesPlusSettingsTab): SettingDe
           control: { type: "toggle", key: "trackOpenFiles" },
         },
         {
+          name: TOGGLE_TEXT.preserveRibbon.name,
+          desc: TOGGLE_TEXT.preserveRibbon.desc,
+          control: { type: "toggle", key: "preserveRibbon" },
+        },
+        {
           name: TOGGLE_TEXT.systemDarkMode.name,
           desc: TOGGLE_TEXT.systemDarkMode.desc,
           control: { type: "toggle", key: "systemDarkMode" },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,6 +42,8 @@ function pathJoin (parts: string[], sep = "/"): string {
   }).join(sep);
 }
 
+export const RIBBON_KEY = "left-ribbon";
+
 export default class Utils {
   SETTINGS_ATTR = "workspaces-plus:settings-v1";
   workspacePlugin: WorkspacePluginInstance;
@@ -286,6 +288,31 @@ export default class Utils {
     const currentLayout = workspace.getLayout();
     newLayout.main = currentLayout["main"] as WorkspaceLayoutNode;
     void workspace.changeLayout(newLayout);
+  }
+
+  syncRibbonAcrossWorkspaces (sourceLayout?: Record<string, unknown>): number {
+    const layout = sourceLayout ?? this.app.workspace.getLayout();
+    if (!layout || !(RIBBON_KEY in layout) || layout[RIBBON_KEY] === undefined) return 0;
+    const ribbonData: unknown = JSON.parse(JSON.stringify(layout[RIBBON_KEY]));
+
+    let count = 0;
+    for (const ws of Object.values(this.workspacePlugin.workspaces)) {
+      if (ws && typeof ws === "object") {
+        ws[RIBBON_KEY] = JSON.parse(JSON.stringify(ribbonData));
+        count++;
+      }
+    }
+    return count;
+  }
+
+  preserveRibbonInLayout (targetLayout: Workspaces, ribbonSource: Record<string, unknown>): Workspaces {
+    const result: Workspaces = Object.assign({}, targetLayout);
+    if (RIBBON_KEY in ribbonSource && ribbonSource[RIBBON_KEY] !== undefined) {
+      result[RIBBON_KEY] = JSON.parse(JSON.stringify(ribbonSource[RIBBON_KEY]));
+    } else {
+      delete result[RIBBON_KEY];
+    }
+    return result;
   }
 
   // Template string rendering with math. Credit to Liam Cain https://github.com/liamcain/obsidian-daily-notes-interface

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -287,20 +287,31 @@ export default class Utils {
     const workspace = this.app.workspace;
     const currentLayout = workspace.getLayout();
     newLayout.main = currentLayout["main"] as WorkspaceLayoutNode;
-    void workspace.changeLayout(newLayout);
+    // Mode switches never go through preserveRibbonInLayout's other call site (main.ts's
+    // loadWorkspace patch only covers plain workspace loads), so without this a mode's own
+    // stored ribbon -- usually just whatever was last synced into it -- would silently replace
+    // the ribbon the user currently has whenever preserveRibbon is on.
+    const layoutToApply = this.plugin.settings.preserveRibbon
+      ? this.preserveRibbonInLayout(newLayout, currentLayout)
+      : newLayout;
+    void workspace.changeLayout(layoutToApply);
   }
 
-  syncRibbonAcrossWorkspaces (): number {
+  // Returns the number of real workspaces synced, or null if there's no ribbon on the current
+  // layout to sync in the first place -- callers need to tell those two "nothing happened"
+  // cases apart to report an accurate message.
+  syncRibbonAcrossWorkspaces (): number | null {
     const layout = this.app.workspace.getLayout();
-    if (!layout || !(RIBBON_KEY in layout) || layout[RIBBON_KEY] === undefined) return 0;
-    const ribbonData: unknown = JSON.parse(JSON.stringify(layout[RIBBON_KEY]));
+    if (!(RIBBON_KEY in layout) || layout[RIBBON_KEY] === undefined) return null;
+    const ribbonJson = JSON.stringify(layout[RIBBON_KEY]);
 
     let count = 0;
-    for (const ws of Object.values(this.workspacePlugin.workspaces)) {
-      if (ws && typeof ws === "object") {
-        ws[RIBBON_KEY] = JSON.parse(JSON.stringify(ribbonData));
-        count++;
-      }
+    for (const [name, ws] of Object.entries(this.workspacePlugin.workspaces)) {
+      // Modes are keyed into this same map but aren't "workspaces" this setting is about --
+      // mergeSidebarLayout() above handles ribbon preservation for mode switches on its own.
+      if (this.isMode(name)) continue;
+      ws[RIBBON_KEY] = JSON.parse(ribbonJson);
+      count++;
     }
     return count;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -290,8 +290,8 @@ export default class Utils {
     void workspace.changeLayout(newLayout);
   }
 
-  syncRibbonAcrossWorkspaces (sourceLayout?: Record<string, unknown>): number {
-    const layout = sourceLayout ?? this.app.workspace.getLayout();
+  syncRibbonAcrossWorkspaces (): number {
+    const layout = this.app.workspace.getLayout();
     if (!layout || !(RIBBON_KEY in layout) || layout[RIBBON_KEY] === undefined) return 0;
     const ribbonData: unknown = JSON.parse(JSON.stringify(layout[RIBBON_KEY]));
 
@@ -306,12 +306,11 @@ export default class Utils {
   }
 
   preserveRibbonInLayout (targetLayout: Workspaces, ribbonSource: Record<string, unknown>): Workspaces {
+    // No ribbon captured to preserve -- leave the target's own saved ribbon state alone
+    // rather than stripping it, so switching still degrades to the pre-preserveRibbon behavior.
+    if (!(RIBBON_KEY in ribbonSource) || ribbonSource[RIBBON_KEY] === undefined) return targetLayout;
     const result: Workspaces = Object.assign({}, targetLayout);
-    if (RIBBON_KEY in ribbonSource && ribbonSource[RIBBON_KEY] !== undefined) {
-      result[RIBBON_KEY] = JSON.parse(JSON.stringify(ribbonSource[RIBBON_KEY]));
-    } else {
-      delete result[RIBBON_KEY];
-    }
+    result[RIBBON_KEY] = JSON.parse(JSON.stringify(ribbonSource[RIBBON_KEY]));
     return result;
   }
 

--- a/tests/mobileGating.test.js
+++ b/tests/mobileGating.test.js
@@ -28,6 +28,7 @@ const DEFAULT_SETTINGS = {
   modeSwitcherRibbon: false,
   replaceNativeRibbon: false,
   trackOpenFiles: true,
+  preserveRibbon: false,
   restoreLayoutOnStartup: false,
 };
 
@@ -130,6 +131,11 @@ const loadWith = async (isMobile, savedData) => {
     await check(`${plat} + saved ribbon value -> respected verbatim`, async () => {
       assert.strictEqual((await loadWith(isMobile, { workspaceSwitcherRibbon: true })).workspaceSwitcherRibbon, true);
       assert.strictEqual((await loadWith(isMobile, { workspaceSwitcherRibbon: false })).workspaceSwitcherRibbon, false);
+    });
+
+    await check(`${plat} + saved preserveRibbon value -> respected verbatim`, async () => {
+      assert.strictEqual((await loadWith(isMobile, { preserveRibbon: true })).preserveRibbon, true);
+      assert.strictEqual((await loadWith(isMobile, { preserveRibbon: false })).preserveRibbon, false);
     });
   }
 


### PR DESCRIPTION
By default, Obsidian workspaces save and restore the `left-ribbon` state (icon ordering, pinned icons, visibility), which causes workspace switches to overwrite any changes made to the ribbon layout.
This PR introduces a new setting (`preserveRibbon`) to allow keeping ribbon icons consistent across workspace switches.

### Changes
- New Setting (`preserveRibbon`): When enabled, switching workspaces preserves the active ribbon layout instead of reverting to the target workspace's saved ribbon state. Disabled by default.
- Auto-sync on save: When `preserveRibbon` is enabled, saving a workspace propagates the current ribbon state across all workspaces.
- Command (`Sync current ribbon layout to all workspaces`): Adds a command to the command palette to manually sync the active ribbon configuration to all saved workspaces.